### PR TITLE
Add Official Handbrake repository

### DIFF
--- a/video-transcoding/Dockerfile
+++ b/video-transcoding/Dockerfile
@@ -3,6 +3,9 @@
 FROM ntodd/ruby-xenial:2.3.1
 MAINTAINER Nate Todd
 
+RUN apt-get update -qq && apt-get install -y software-properties-common
+RUN add-apt-repository ppa:stebbins/handbrake-releases
+
 # Install dependencies
 RUN apt-get update -qq && apt-get install -y \
   ffmpeg \


### PR DESCRIPTION
Hi Nate, offering you this PR that uses the official Handbrake repository for releases because the default repository contains an old version. For example, currently the default version is 0.10.2 but the release is on 1.0.1. 

--

Add the Handbrake repository and pull Handbrake from there because the
default repository does not contain up-to-date versions of Handbrake.